### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/examples/milton-anno-bandstand/pom.xml
+++ b/examples/milton-anno-bandstand/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.cardme</groupId>

--- a/examples/milton-anno-ref/pom.xml
+++ b/examples/milton-anno-ref/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/examples/milton-ref/pom.xml
+++ b/examples/milton-ref/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/milton-server-ce/pom.xml
+++ b/milton-server-ce/pom.xml
@@ -147,7 +147,7 @@
 			<artifactId>commons-collections</artifactId>
 			<groupId>commons-collections</groupId>
 			<type>jar</type>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.restlet.jse</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
